### PR TITLE
Fixes github repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Add this to your application's `shard.yml`:
 ```yaml
 dependencies:
   notify:
-    github: woodruffw/notify
+    github: woodruffw/notify.cr
 ```
 
 ## Usage


### PR DESCRIPTION
Hi @woodruffw 

Very nice library :+1: 

Tested on KDE plasma 5.12.5

![screenshot_20180618_143819](https://user-images.githubusercontent.com/3067335/41558035-3f66cf78-7305-11e8-8d7f-31327a09ad2d.png)

This PR fixes wrong github repo name on README `notify` to `notify.cr`
